### PR TITLE
Support Trimesh 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "imageio>=2.0.0,<3.0.0",
     "tqdm>=4.0.0,<5.0.0",
     "rich>=13.3.3,<15.0.0",
-    "trimesh>=3.21.7,<5.0.0",
+    "trimesh>=3.21.7,<6.0.0",
     "typing_extensions>=4.0.0",
     # TODO: migrate to backports.zstd when we drop Python 3.8 support.
     # https://pypi.org/project/backports.zstd/

--- a/tests/test_trimesh_compatibility.py
+++ b/tests/test_trimesh_compatibility.py
@@ -1,0 +1,19 @@
+import numpy as np
+import trimesh
+
+import viser
+
+
+def test_trimesh_mesh_helpers() -> None:
+    server = viser.ViserServer(port=0, verbose=False)
+    try:
+        mesh = trimesh.creation.box(extents=(1.0, 2.0, 3.0))
+        server.scene.add_mesh_trimesh("/mesh", mesh)
+        server.scene.add_batched_meshes_trimesh(
+            "/batched",
+            mesh,
+            batched_wxyzs=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+            batched_positions=np.array([[0.0, 0.0, 0.0]], dtype=np.float32),
+        )
+    finally:
+        server.stop()


### PR DESCRIPTION
## Summary

- allow Trimesh 5 in Viser's runtime dependency range
- add coverage for both Trimesh scene helpers

## Motivation

Viser currently declares `trimesh<5`, which prevents environments from resolving Trimesh 5 even though the scene integration paths remain compatible. The new test exercises both `add_mesh_trimesh()` and `add_batched_meshes_trimesh()` with a real Trimesh object.

## Test plan

- Python 3.14.6 with Trimesh 5.0.0: `pytest tests/test_trimesh_compatibility.py` — 1 passed
- Python 3.14.6 with Trimesh 5.0.0: `pytest --ignore=tests/e2e` — 760 passed
- Ruff lint and formatting checks pass
- separate interactive smoke test served a 27,334-vertex, 53,968-face OBJ through the Trimesh helper under warnings-as-errors
- `git diff --check origin/main...HEAD`
