### PR TITLE
Use inspect.iscoroutinefunction on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ viser-build-client = "viser._client_autobuild:build_client_entrypoint"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = [
+    "error:.*asyncio\\.iscoroutinefunction.*:DeprecationWarning",
+]
 markers = [
     "e2e: end-to-end browser tests (require Playwright)",
 ]

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import builtins
 import colorsys
 import dataclasses
 import functools
+import inspect
 import threading
 import time
 import uuid
@@ -441,7 +441,7 @@ class GuiApi:
         if client is None:
             return
         for cb in handle_state.update_cb:
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 await cb(GuiEvent(client, client_id, handle))
             else:
                 self._thread_executor.submit(
@@ -471,7 +471,7 @@ class GuiApi:
 
         # Call all callbacks for this frequency.
         for cb in callbacks:
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 await cb(GuiEvent(client, client_id, handle))
             else:
                 self._thread_executor.submit(
@@ -495,7 +495,7 @@ class GuiApi:
             return
 
         for cb in handle._submit_cb:
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 await cb(GuiEvent(client, client_id, handle))
             else:
                 self._thread_executor.submit(
@@ -611,7 +611,7 @@ class GuiApi:
         if client is None:
             return
         for cb in handle_state.update_cb:
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 self._event_loop.create_task(cb(GuiEvent(client, client_id, handle)))
             else:
                 self._thread_executor.submit(
@@ -685,7 +685,7 @@ class GuiApi:
             return
 
         for cb in handle_state.trigger_cb:
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 await cb(CommandEvent(client, client_id, handle))
             else:
                 self._thread_executor.submit(

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import inspect
 import io
 import math
 import time
@@ -3262,7 +3263,7 @@ class SceneApi:
         branches (print_awaited_callback_error / print_threadpool_errors):
         one throwing callback must not starve its sibling callbacks or
         abort the caller (message dispatch, disconnect teardown)."""
-        if asyncio.iscoroutinefunction(cb):
+        if inspect.iscoroutinefunction(cb):
             try:
                 await cb(event)
             except Exception as exc:
@@ -3683,7 +3684,7 @@ class SceneApi:
         # isolated like every other callback path: one throwing cleanup
         # must not starve its siblings or leave the list uncleared.
         for cleanup in list(self._scene_pointer_done_cb):
-            if asyncio.iscoroutinefunction(cleanup):
+            if inspect.iscoroutinefunction(cleanup):
                 # run_coroutine_threadsafe, not create_task: callback removal
                 # can run on a user thread, and create_task is neither
                 # thread-safe nor guaranteed to wake the loop.

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 import copy
 import dataclasses
+import inspect
 import warnings
 from collections.abc import Coroutine
 from typing import (
@@ -1736,7 +1736,7 @@ def _phase_filtered_wrapper(
     ``on_drag_start`` / ``on_drag_end`` methods. Tagged so
     ``remove_*`` can locate it by the original ``func`` identity."""
 
-    if asyncio.iscoroutinefunction(func):
+    if inspect.iscoroutinefunction(func):
 
         async def async_wrapper(event: TransformControlsEvent) -> None:
             if event.phase == phase:

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import dataclasses
+import inspect
 import io
 import math
 import mimetypes
@@ -1235,7 +1236,7 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
                     await self._dispatch_client_callbacks(connect_cbs, client)
 
                 for camera_cb in client.camera._state.camera_cb:
-                    if asyncio.iscoroutinefunction(camera_cb):
+                    if inspect.iscoroutinefunction(camera_cb):
                         await camera_cb(client.camera)
                     else:
                         self._thread_executor.submit(
@@ -1642,7 +1643,7 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         awaited in order, sync callbacks on the thread pool, every callback
         exception-isolated so one failure cannot starve its siblings."""
         for cb in callbacks:
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 try:
                     await cb(client)
                 except Exception as exc:
@@ -1690,7 +1691,7 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
         # This makes sure that the the callback is applied to any clients that
         # connect between the two lines.
         for client in clients:
-            if asyncio.iscoroutinefunction(cb):
+            if inspect.iscoroutinefunction(cb):
                 # run_coroutine_threadsafe, not create_task: registration
                 # typically happens on a user thread, and create_task is
                 # neither thread-safe nor guaranteed to wake the loop.

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -9,6 +9,7 @@ import dataclasses
 import gzip
 import hashlib
 import http
+import inspect
 import logging
 import mimetypes
 import queue
@@ -319,7 +320,7 @@ class WebsockMessageHandler:
             # (e.g. get_render's response callback), which would otherwise skip
             # the next handler in a live iteration.
             for cb in list(self._incoming_handlers[type(message)]):
-                if asyncio.iscoroutinefunction(cb):
+                if inspect.iscoroutinefunction(cb):
                     await cb(client_id, message)
                 else:
                     cb(client_id, message)
@@ -615,7 +616,7 @@ class WebsockServer(WebsockMessageHandler):
 
             # New connection callbacks.
             for cb in self._client_connect_cb:
-                if asyncio.iscoroutinefunction(cb):
+                if inspect.iscoroutinefunction(cb):
                     await cb(client_connection)
                 else:
                     cb(client_connection)
@@ -698,7 +699,7 @@ class WebsockServer(WebsockMessageHandler):
 
                 # Disconnection callbacks.
                 for cb in self._client_disconnect_cb:
-                    if asyncio.iscoroutinefunction(cb):
+                    if inspect.iscoroutinefunction(cb):
                         await cb(client_connection)
                     else:
                         cb(client_connection)


### PR DESCRIPTION
## Summary

- replace deprecated `asyncio.iscoroutinefunction()` calls with `inspect.iscoroutinefunction()`
- promote this specific deprecation to an error in pytest so future uses are caught by the existing Python 3.14 CI job

## Motivation

Python 3.14 deprecates `asyncio.iscoroutinefunction()` in favor of the canonical `inspect` function. Viser's non-browser suite currently emits this warning 42 times across its callback dispatch paths, but the existing Python 3.14 CI job does not fail on it.

`inspect.iscoroutinefunction()` has the same callback-classification behavior for these call sites and avoids the API scheduled for removal in Python 3.16.

## Test plan

- Python 3.14.6: `pytest --ignore=tests/e2e` — 759 passed
- the targeted warning filter is active in `pyproject.toml`
- Ruff lint and formatting checks pass for all modified modules
- `git diff --check origin/main...HEAD`
