### PR TITLE
Harden release builds: asset-aware cache key, wheel contents check

### DIFF
--- a/.github/actions/build-client/action.yml
+++ b/.github/actions/build-client/action.yml
@@ -17,8 +17,11 @@ runs:
       with:
         path: src/viser/client/build
         # `build/` and `node_modules/` are gitignored, so on a fresh checkout
-        # this hashes only tracked source -- a stable content address.
-        key: viser-client-build-${{ runner.os }}-${{ hashFiles('src/viser/client/**') }}
+        # this hashes only tracked source -- a stable content address. The
+        # build also embeds assets from _assets (the default environment map
+        # imported by App.tsx), so those are part of the key: without them a
+        # changed asset would silently reuse a stale cached build.
+        key: viser-client-build-${{ runner.os }}-${{ hashFiles('src/viser/client/**', 'src/viser/_assets/**') }}
 
     - name: Use Node.js
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,10 +37,36 @@ jobs:
           rm -rf src/viser/client/*
           git checkout src/viser/client
           mv ./__built_client src/viser/client/build
-      - name: Build and publish
+      - name: Build
+        run: uv build
+      - name: Verify wheel contents
+        # The client build and the HDRI presets are runtime dependencies of
+        # the installed package (the client is served from build/index.html;
+        # configure_environment_map reads _assets/hdri from disk), but both
+        # sit outside the usual Python-file packaging path -- fail the
+        # release if either is missing from the wheel.
+        run: |
+          python3 - <<'EOF'
+          import glob
+          import pathlib
+          import zipfile
+
+          (wheel,) = glob.glob("dist/*.whl")
+          names = set(zipfile.ZipFile(wheel).namelist())
+          missing = [
+              path
+              for path in ["viser/client/build/index.html"]
+              + sorted(
+                  f"viser/_assets/hdri/{f.name}"
+                  for f in pathlib.Path("src/viser/_assets/hdri").iterdir()
+              )
+              if path not in names
+          ]
+          assert not missing, f"Missing from {wheel}: {missing}"
+          print(f"{wheel} OK: client build + {len(names)} files")
+          EOF
+      - name: Publish
         env:
           UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
           UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          uv build
-          uv publish
+        run: uv publish


### PR DESCRIPTION
Two release-pipeline fixes ahead of the next version bump:

- The shared client-build cache key now includes `src/viser/_assets/**`, since the client build embeds the default environment map from there; previously an asset change would silently reuse a stale cached build (including in the publish job).
- The publish workflow verifies the wheel contains `viser/client/build/index.html` and every HDRI preset before uploading, since both are runtime dependencies that live outside the usual Python packaging path.

Verified locally: `uv build` produces a wheel containing the client build and all 10 HDRI presets, with no stray node files.