### PR TITLE
Fix markdown data: images, avoid redundant environment-map decodes

### DIFF
--- a/src/viser/client/src/HDRJPGEnvironment.tsx
+++ b/src/viser/client/src/HDRJPGEnvironment.tsx
@@ -30,6 +30,22 @@ interface HDRJPGEnvironmentProps {
 // Initial canvas opacity while loading.
 const LOADING_OPACITY = 0.05;
 
+/** Byte-level equality for environment sources: every EnvironmentMapMessage
+ * re-sends the image bytes (rotating the environment or changing a scalar
+ * intensity re-sends the same preset), and msgpack decodes a fresh
+ * Uint8Array each time. Comparing contents lets the decode effect below
+ * skip identical images, keeping scalar-parameter updates cheap. */
+function sourcesEqual(
+  a: string | Uint8Array<ArrayBuffer>,
+  b: string | Uint8Array<ArrayBuffer>,
+): boolean {
+  if (a === b) return true;
+  if (typeof a === "string" || typeof b === "string") return a === b;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
 export function HDRJPGEnvironment({
   source,
   background = false,
@@ -42,6 +58,14 @@ export function HDRJPGEnvironment({
   const gl = useThree((state) => state.gl);
   const scene = useThree((state) => state.scene);
   const [texture, setTexture] = useState<THREE.Texture | null>(null);
+
+  // Keep the previous source reference while the bytes are unchanged, so the
+  // load effect's dependency doesn't churn on every message.
+  const stableSourceRef = useRef(source);
+  if (!sourcesEqual(stableSourceRef.current, source)) {
+    stableSourceRef.current = source;
+  }
+  const stableSource = stableSourceRef.current;
 
   // Track fade-in progress (0 to 1).
   const fadeProgress = useRef(0);
@@ -59,9 +83,9 @@ export function HDRJPGEnvironment({
 
     // Bytes from the server are loaded through a temporary object URL.
     const url =
-      typeof source === "string"
-        ? source
-        : URL.createObjectURL(new Blob([source], { type: "image/jpeg" }));
+      typeof stableSource === "string"
+        ? stableSource
+        : URL.createObjectURL(new Blob([stableSource], { type: "image/jpeg" }));
 
     loader.load(
       url,
@@ -93,9 +117,9 @@ export function HDRJPGEnvironment({
 
     return () => {
       disposed = true;
-      if (typeof source !== "string") URL.revokeObjectURL(url);
+      if (typeof stableSource !== "string") URL.revokeObjectURL(url);
     };
-  }, [source, gl]);
+  }, [stableSource, gl]);
 
   // Dispose of previous texture when changed.
   useEffect(() => {

--- a/src/viser/client/src/Markdown.tsx
+++ b/src/viser/client/src/Markdown.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
+import ReactMarkdown, {
+  defaultUrlTransform,
+  type Components,
+} from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeColorChips from "rehype-color-chips";
 import { rehypeRawDom } from "./rehypeRawDom";
@@ -167,14 +170,30 @@ const components: Components = {
  * sanitization (via rehypeRawDom) -- script tags included -- so content must
  * come from a trusted server, exactly as before.
  */
-export default function Markdown(props: { children?: string }) {
+// The server embeds image_root images as data: URIs, which react-markdown's
+// default URL transform strips (its allow-list is http/https/mailto/...).
+// Content already comes from a trusted server -- raw HTML renders
+// unsanitized above -- so pass data: through and keep the default handling
+// for every other scheme.
+function urlTransform(url: string): string {
+  return url.startsWith("data:") ? url : defaultUrlTransform(url);
+}
+
+function Markdown(props: { children?: string }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeRawDom, rehypeCodeblock, rehypeColorChips]}
       components={components}
+      urlTransform={urlTransform}
     >
       {props.children ?? ""}
     </ReactMarkdown>
   );
 }
+
+// Memoized: parsing runs on every render otherwise, and markdown elements
+// often sit inside containers that re-render for unrelated reasons (theme
+// changes, sibling GUI updates). With a string child, shallow prop
+// comparison makes this exactly "re-parse when content changes".
+export default React.memo(Markdown);


### PR DESCRIPTION
Two fixes for regressions that slipped through #771, both release-blocking:

- `add_markdown(image_root=...)` images were broken: react-markdown's default `urlTransform` strips the `data:` URIs the server embeds them as (verified against the shipped `03_markdown.py` example); `data:` now passes through, and the Markdown component is memoized so parent re-renders don't re-parse.
- Animating environment-map scalars (rotation, intensity) re-decoded the HDR gainmap on every message, since each re-sent payload decodes to a fresh `Uint8Array`; the client now keeps the previous reference while bytes are unchanged.